### PR TITLE
修复启动时可能增加空直播间的问题、增加新的时间参数

### DIFF
--- a/BiLiRoku/RoomList.cs
+++ b/BiLiRoku/RoomList.cs
@@ -162,16 +162,23 @@ namespace BiliRoku
 
             var safeTitle = SafetyFileName(Title);
             var safeUsername = SafetyFileName(Username);
-
+            
             path = path.Replace("{roomid}", Roomid);
             path = path.Replace("{title}", safeTitle);
             path = path.Replace("{username}", safeUsername);
-            path = path.Replace("{Y}", DateTime.Now.ToString("yy"));
-            path = path.Replace("{M}", DateTime.Now.ToString("MM"));
-            path = path.Replace("{d}", DateTime.Now.ToString("dd"));
-            path = path.Replace("{H}", DateTime.Now.ToString("HH"));
-            path = path.Replace("{m}", DateTime.Now.ToString("mm"));
-            path = path.Replace("{s}", DateTime.Now.ToString("ss"));
+            path = path.Replace("{Y}", DateTime.Now.Year.ToString());
+            path = path.Replace("{M}", DateTime.Now.Month.ToString());
+            path = path.Replace("{d}", DateTime.Now.Day.ToString());
+            path = path.Replace("{H}", DateTime.Now.Hour.ToString());
+            path = path.Replace("{m}", DateTime.Now.Minute.ToString());
+            path = path.Replace("{s}", DateTime.Now.Second.ToString());
+            path = path.Replace("{YY}", DateTime.Now.ToString("yy"));
+            path = path.Replace("{MM}", DateTime.Now.ToString("MM"));
+            path = path.Replace("{dd}", DateTime.Now.ToString("dd"));
+            path = path.Replace("{HH}", DateTime.Now.ToString("HH"));
+            path = path.Replace("{mm}", DateTime.Now.ToString("mm"));
+            path = path.Replace("{ss}", DateTime.Now.ToString("ss"));
+            path = path.Replace("{YYYY}", DateTime.Now.ToString("yyyy"));
             return path;
         }
 

--- a/BiLiRoku/RoomList.cs
+++ b/BiLiRoku/RoomList.cs
@@ -166,12 +166,12 @@ namespace BiliRoku
             path = path.Replace("{roomid}", Roomid);
             path = path.Replace("{title}", safeTitle);
             path = path.Replace("{username}", safeUsername);
-            path = path.Replace("{Y}", DateTime.Now.Year.ToString());
-            path = path.Replace("{M}", DateTime.Now.Month.ToString());
-            path = path.Replace("{d}", DateTime.Now.Day.ToString());
-            path = path.Replace("{H}", DateTime.Now.Hour.ToString());
-            path = path.Replace("{m}", DateTime.Now.Minute.ToString());
-            path = path.Replace("{s}", DateTime.Now.Second.ToString());
+            path = path.Replace("{Y}", DateTime.Now.ToString("yy"));
+            path = path.Replace("{M}", DateTime.Now.ToString("MM"));
+            path = path.Replace("{d}", DateTime.Now.ToString("dd"));
+            path = path.Replace("{H}", DateTime.Now.ToString("HH"));
+            path = path.Replace("{m}", DateTime.Now.ToString("mm"));
+            path = path.Replace("{s}", DateTime.Now.ToString("ss"));
             return path;
         }
 
@@ -359,6 +359,7 @@ namespace BiliRoku
 
         public void AddRoom(string roomid, bool restore = false)
         {
+
             if(this.Count(i => i.Roomid == roomid) > 0)
             {
                 if(restore == false) MessageBox.Show("直播间ID已经存在。", "添加失败", MessageBoxButton.OK, MessageBoxImage.Asterisk);
@@ -378,9 +379,10 @@ namespace BiliRoku
 
         public void RestoreRooms()
         {
-            if (config.RoomId != null)
+            if (config.RoomId != null && config.RoomId != "")
             {
                 var roomids = config.RoomId.Split(',');
+                
                 foreach (var roomid in roomids)
                 {
                     AddRoom(roomid, true);

--- a/BiLiRoku/SavePathSetting.xaml.cs
+++ b/BiLiRoku/SavePathSetting.xaml.cs
@@ -100,8 +100,10 @@ namespace BiliRoku
             MessageBox.Show(this, @"说明：
 
 {roomid}--房间号 {title}--房间名 {username}--主播用户名
-{Y}--年 {M}--月 {d}--日
-{h}--时 {m}--分 {s}--秒
+{Y}--年(四位) {M}--月 {d}--日
+{H}--时 {m}--分 {s}--秒 (不自动补0,一位数时占一位)
+{YY}(两位年份){MM}{dd}{HH}{mm}{ss}分别对应上方补0(保持占两位数)
+{YYYY} 四位年份
 注：若文件名中不含时间变量，则为固定文件名，固定文件名可能会被覆盖。
 文件名中也可出现“\”字符，这时会建立子目录。", "保存文件名变量说明", MessageBoxButton.OK, MessageBoxImage.Information);
         }


### PR DESCRIPTION
**修复启动时可能增加空直播间的问题**
现有发布版本中,若清空已添加的直播间重新启动时,程序会在注册表读入一个空字符串,导致增加一个空直播间,从而造成错误。(RoomList.cs)
**增加新的时间参数**
文件命名规则:在原有时间参数基础上,增加
- {YY} (两位年份)
- {MM} (两位月份)
- {dd} (两位天)
- {HH} (两位时)
- {mm} (两位分)
- {ss} (两位秒)
- {YYYY} (四位年份)

以上参数可**固定位数**,方便文件命名。(SavePathSetting.xaml.cs)